### PR TITLE
Pass current language in search requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,15 @@ Changelog
 
 https://github.com/openoereb/oereb_client/milestone/2
 
+- Drop support for Python 2.7 and 3.5
 - Application re-design
+- Configurable search
 - Update Bootstrap and Openlayers
 - Use React-redux instead of AngularJS
 - Use Jest instead of Karma
 - Use Webpack instead of Closure Compiler
 - Fix duplicate workflow runs
 - Dependency updates
-- Drop support for Python 2.7 and 3.5
 
 1.3.8
 *****

--- a/oereb_client/static/src/api/search.js
+++ b/oereb_client/static/src/api/search.js
@@ -1,6 +1,7 @@
-export const searchTerm = function (applicationUrl, value) {
+export const searchTerm = function (applicationUrl, term, language) {
   const url = new URL(applicationUrl + 'search');
-  url.searchParams.append('term', value);
+  url.searchParams.append('term', term);
+  url.searchParams.append('lang', language);
   let cancel;
   const result = {
     promise: new Promise((resolve, reject) => {

--- a/oereb_client/static/src/component/menu/menu.js
+++ b/oereb_client/static/src/component/menu/menu.js
@@ -106,7 +106,7 @@ const OerebMenu = function () {
     }
     if (searchValue.length > 0) {
       setLoading(true);
-      const request = searchTerm(applicationUrl, searchValue);
+      const request = searchTerm(applicationUrl, searchValue, currentLanguage);
       const searchPromise = request.promise;
       setPendingRequest(request);
       searchPromise.then((results) => {


### PR DESCRIPTION
Add missing parameter `lang` in search requests to enable multilingual support.