### PR TITLE
Add configurable search endpoint

### DIFF
--- a/oereb_client.yml
+++ b/oereb_client.yml
@@ -60,6 +60,8 @@ oereb_client:
   # service_url: https://my.oereb-web-service.ch/
 
   # Search configuration
+  # Specify a list to use the internal search proxy or specify an URL to use an external endpoint.
+  # search: https://my.search-endpoint.ch/
   search:
     - title:
         - Language: en

--- a/oereb_client/static/src/api/search.js
+++ b/oereb_client/static/src/api/search.js
@@ -1,5 +1,5 @@
-export const searchTerm = function (serviceUrl, term, language) {
-  const url = new URL(serviceUrl + 'search');
+export const searchTerm = function (searchUrl, term, language) {
+  const url = new URL(searchUrl);
   url.searchParams.append('term', term);
   url.searchParams.append('lang', language);
   let cancel;

--- a/oereb_client/static/src/component/menu/menu.js
+++ b/oereb_client/static/src/component/menu/menu.js
@@ -25,7 +25,7 @@ const OerebMenu = function () {
   const symbolZoomEnabled = useSelector((state) => state.symbolZoom).enabled;
   const history = useSelector((state) => state.history).elements;
   const dispatch = useDispatch();
-  const applicationUrl = config.application_url;
+  const searchUrl = config.search_url;
   const serviceUrl = config.service_url;
 
   const language = useSelector((state) => state.language);
@@ -110,7 +110,7 @@ const OerebMenu = function () {
     }
     if (searchValue.length > 0) {
       setLoading(true);
-      const request = searchTerm(applicationUrl, searchValue, currentLanguage);
+      const request = searchTerm(searchUrl, searchValue, currentLanguage);
       const searchPromise = request.promise;
       setPendingRequest(request);
       searchPromise.then((results) => {

--- a/oereb_client/views/index.py
+++ b/oereb_client/views/index.py
@@ -49,7 +49,10 @@ class Index(object):
         if not isinstance(self.config_.get('availability'), dict):
             raise ConfigurationError('Missing "availability" configuration')
 
-        if not isinstance(self.config_.get('search'), list):
+        if not (
+            isinstance(self.config_.get('search'), list) or
+            isinstance(self.config_.get('search'), str)
+        ):
             raise ConfigurationError('Missing "search" configuration')
 
         if not isinstance(self.config_.get('support'), dict):
@@ -140,6 +143,14 @@ class Index(object):
             '{0}/index'.format(self.request_.route_prefix)
         )
 
+    def get_search_url_(self):
+        search = self.config_.get('search', None)
+        if isinstance(search, str):
+            return search
+        return self.request_.route_url(
+            '{0}/search'.format(self.request_.route_prefix)
+        )
+
     def get_config(self):
         """
         Returns the JSON-encoded configuration.
@@ -153,6 +164,7 @@ class Index(object):
                 '{0}/index'.format(self.request_.route_prefix)
             ),
             'service_url': self.get_service_url_(),
+            'search_url': self.get_search_url_(),
             'application': self.get_application_config_(),
             'version': __version__,
             'view': self.config_.get('view', {}),

--- a/test/py/test_views_index.py
+++ b/test/py/test_views_index.py
@@ -99,6 +99,7 @@ def test_render(mock_request):
     with testConfig(settings=settings) as config:
         config.route_prefix = None
         config.add_route('{0}/index'.format(config.route_prefix), '/')
+        config.add_route('{0}/search'.format(config.route_prefix), '/search')
         config.add_static_view('static', 'oereb_client:static', cache_max_age=3600)
         index = Index(mock_request)
         assert index.render() == {
@@ -114,11 +115,13 @@ def test_get_config(mock_request):
     with testConfig(settings=settings) as config:
         config.route_prefix = None
         config.add_route('{0}/index'.format(config.route_prefix), '/')
+        config.add_route('{0}/search'.format(config.route_prefix), '/search')
         config.add_static_view('static', 'oereb_client:static', cache_max_age=3600)
         index = Index(mock_request)
         assert index.get_config() == {
             'application_url': 'http://example.com/',
             'service_url': 'http://example.com/',
+            'search_url': 'http://example.com/search',
             'application': settings.get('oereb_client').get('application'),
             'version': __version__,
             'view': settings.get('oereb_client').get('view'),
@@ -205,3 +208,16 @@ def test_get_service_url(service_url, result, mock_request):
         config.add_route('{0}/index'.format(config.route_prefix), '/')
         index = Index(mock_request)
         assert index.get_service_url_() == result
+
+
+@pytest.mark.parametrize('search,result', [
+    ([], 'http://example.com/search'),
+    ('http://my.oereb.search/', 'http://my.oereb.search/')
+])
+def test_get_search_url(search, result, mock_request):
+    modified_settings = deepcopy(settings)
+    modified_settings['oereb_client']['search'] = search
+    with testConfig(settings=modified_settings) as config:
+        config.add_route('{0}/search'.format(config.route_prefix), '/search')
+        index = Index(mock_request)
+        assert index.get_search_url_() == result


### PR DESCRIPTION
Specify URL for `search` instead of list to use an external search endpoint.