### PR TITLE
Add a configurable notice shown on application start

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 https://github.com/openoereb/oereb_client/milestone/19
 
+- Add configurable notices shown on application start
+
 2.3.0
 *****
 

--- a/docs/src/Configuration.mdx
+++ b/docs/src/Configuration.mdx
@@ -326,6 +326,17 @@ oereb_client:
       FORMAT: image/png
     opacity: 0.8
     attributions: optional copyright or notice
+
+  # [OPTIONAL] Specify a number of notices that are shown on application start.
+  # The text can be defined in multiple languages. You can also specify one or two
+  # dates to automatically enable and/or disable each notice. The value "null" means
+  # no restriction.
+  messages:
+    - text:
+        en: My example notice
+        de: Meine Beispielmeldung
+      from: null
+      until: null
 ```
 
 ### Search

--- a/docs/src/Configuration.mdx
+++ b/docs/src/Configuration.mdx
@@ -327,6 +327,20 @@ oereb_client:
     opacity: 0.8
     attributions: optional copyright or notice
 
+  # [OPTIONAL] Specify the YAML file containing the messages initially shown on
+  # application start (see section below for more information about its content).
+  # Default: messages.yml
+  messages_file: path/to/my/custom/messages.yml
+```
+
+### Messages file
+
+You can optionally add a file with messages to be shown on application start. This
+can be used to announce new features, new data or service maintenance. If the file
+cannot be found, no messages are shown. The contents of the file should look like
+the following example.
+
+```yaml
   # [OPTIONAL] Specify a number of notices that are shown on application start.
   # The text can be defined in multiple languages. You can also specify one or two
   # dates to automatically enable and/or disable each notice. The value "null" means

--- a/messages.yml
+++ b/messages.yml
@@ -1,0 +1,7 @@
+messages:
+  - text:
+      en: This is just a demo to show the notice function.
+      de: Dies ist nur eine Demo der Benachtichtigungsfunktion.
+      fr: Il s'agit simplement d'une démo pour montrer la fonction de notification.
+    from: null
+    until: null

--- a/oereb_client.yml
+++ b/oereb_client.yml
@@ -126,11 +126,3 @@ oereb_client:
   show_scale_bar: false
 
   enable_rotation: true
-
-  messages:
-    - text:
-        en: This is just a demo to show the notice function.
-        de: Dies ist nur eine Demo der Benachtichtigungsfunktion.
-        fr: Il s'agit simplement d'une démo pour montrer la fonction de notification.
-      from: null
-      until: null

--- a/oereb_client.yml
+++ b/oereb_client.yml
@@ -126,3 +126,11 @@ oereb_client:
   show_scale_bar: false
 
   enable_rotation: true
+
+  messages:
+    - text:
+        en: This is just a demo to show the notice function.
+        de: Dies ist nur eine Demo der Benachtichtigungsfunktion.
+        fr: Il s'agit simplement d'une démo pour montrer la fonction de notification.
+      from: null
+      until: null

--- a/oereb_client/static/i18n/de/locale.json
+++ b/oereb_client/static/i18n/de/locale.json
@@ -113,5 +113,10 @@
     "user_guide": {
       "title": "Benutzerhandbuch"
     }
+  },
+  "message": {
+    "error": "Fehler",
+    "info": "Information",
+    "warning": "Warnung"
   }
 }

--- a/oereb_client/static/i18n/en/locale.json
+++ b/oereb_client/static/i18n/en/locale.json
@@ -113,5 +113,10 @@
     "user_guide": {
       "title": "User guide"
     }
+  },
+  "message": {
+    "error": "Error",
+    "info": "Information",
+    "warning": "Warning"
   }
 }

--- a/oereb_client/static/i18n/fr/locale.json
+++ b/oereb_client/static/i18n/fr/locale.json
@@ -113,5 +113,10 @@
     "user_guide": {
       "title": "Aide"
     }
+  },
+  "message": {
+    "error": "Erreur",
+    "info": "Information",
+    "warning": "Alerte"
   }
 }

--- a/oereb_client/static/src/component/app/app.jsx
+++ b/oereb_client/static/src/component/app/app.jsx
@@ -1,6 +1,6 @@
-import {isString} from "lodash";
+import {isArray, isString} from "lodash";
 import PropTypes from "prop-types";
-import React, {useEffect} from "react";
+import React from "react";
 import {useDispatch} from "react-redux";
 
 import {initAvailability, setAvailabilityPrefix} from "../../reducer/availability";
@@ -16,6 +16,7 @@ import OerebMap from "../map/map";
 import OerebMenu from "../menu/menu";
 import OerebMessage from "../message/message";
 import MatomoTracker from "../matomo_tracker/matomo_tracker";
+import { showInfo } from "../../reducer/message";
 
 const App = function (props) {
   const dispatch = useDispatch();
@@ -71,6 +72,13 @@ const App = function (props) {
   let tracker = null;
   if (config["matomo"] && config["matomo"]["url"] && config["matomo"]["site_id"]) {
     tracker = <MatomoTracker matomoUrl={config["matomo"]["url"]} siteId={config["matomo"]["site_id"]} />;
+  }
+
+  // Show initial messages
+  if (isArray(config["messages"])) {
+    config["messages"].forEach(message => {
+      dispatch(showInfo(message["text"], true));
+    });
   }
 
   return (

--- a/oereb_client/static/src/oereb_client.scss
+++ b/oereb_client/static/src/oereb_client.scss
@@ -16,6 +16,7 @@ $border-radius-sm: 0;
 $border-radius-lg: 0;
 $border-radius-xl: 0;
 $border-radius-2xl: 0;
+$toast-background-color: #fff;
 
 @import "bootstrap/scss/bootstrap.scss";
 @import "bootstrap-icons/font/bootstrap-icons.css";

--- a/oereb_client/static/src/reducer/message.js
+++ b/oereb_client/static/src/reducer/message.js
@@ -9,11 +9,21 @@ export const messageSlice = createSlice({
     messages: []
   },
   reducers: {
+    info: (state, action) => {
+      state.messages.push({
+        id: uuidv4(),
+        type: "info",
+        text: action.payload.text,
+        confirmation: action.payload.confirmation,
+        timestamp: Date.now()
+      });
+    },
     warning: (state, action) => {
       state.messages.push({
         id: uuidv4(),
         type: "warning",
-        text: action.payload,
+        text: action.payload.text,
+        confirmation: action.payload.confirmation,
         timestamp: Date.now()
       });
     },
@@ -21,39 +31,66 @@ export const messageSlice = createSlice({
       state.messages.push({
         id: uuidv4(),
         type: "error",
-        text: action.payload,
+        text: action.payload.text,
+        confirmation: action.payload.confirmation,
         timestamp: Date.now()
       });
+    },
+    close: (state, action) => {
+      for (let i = 0; i < state.messages.length; i++) {
+        if (state.messages[i].id === action.payload) {
+          state.messages.splice(i, 1);
+          break;
+        }
+      }
     },
     cleanMessages: (state) => {
       for (let i = state.messages.length; i > 0; i--) {
         const now = Date.now();
-        if (now - state.messages[i - 1].timestamp >= MESSAGE_TIMEOUT) {
-          state.messages.splice(i - 1, 1);
+        if (!state.messages[i-1].confirmation && now - state.messages[i-1].timestamp >= MESSAGE_TIMEOUT) {
+          state.messages.splice(i-1, 1);
         }
       }
     }
   }
 });
 
-export const {cleanMessages, error, warning} = messageSlice.actions;
+export const {cleanMessages, info, error, warning, close} = messageSlice.actions;
 
-export const showWarning = function(text) {
+export const showInfo = function(text, confirmation) {
   return function(dispatch) {
-    dispatch(warning(text));
+    dispatch(info({
+      text: text,
+      confirmation: confirmation || false
+    }));
     setTimeout(() => {
       dispatch(cleanMessages());
     }, MESSAGE_TIMEOUT);
   };
 }
 
-export const showError = function(text) {
+export const showWarning = function(text, confirmation) {
   return function(dispatch) {
-    dispatch(error(text));
+    dispatch(warning({
+      text: text,
+      confirmation: confirmation || false
+    }));
     setTimeout(() => {
       dispatch(cleanMessages());
     }, MESSAGE_TIMEOUT);
-  }
+  };
+}
+
+export const showError = function(text, confirmation) {
+  return function(dispatch) {
+    dispatch(error({
+      text: text,
+      confirmation: confirmation || false
+    }));
+    setTimeout(() => {
+      dispatch(cleanMessages());
+    }, MESSAGE_TIMEOUT);
+  };
 }
 
 export default messageSlice.reducer;

--- a/oereb_client/views/index.py
+++ b/oereb_client/views/index.py
@@ -167,7 +167,7 @@ class Index():
         if isinstance(search, str):
             return search
         return self.request_.route_url(f'{self.request_.route_prefix}/search')
-    
+
     def get_active_messages_(self):
         messages = []
         now = datetime.now()
@@ -243,23 +243,23 @@ class Index():
             'config': self.get_config(),
             'title': self.get_title()
         }
-    
+
     @staticmethod
     def parse_date_(date_string):
         if date_string is None:
             return None
-        
+
         date_formats = [
             "%Y-%m-%d",           # 2025-04-02
             "%d.%m.%Y",           # 02.04.2025
             "%Y-%m-%d %H:%M:%S",  # 2025-04-02 14:30:45
             "%d.%m.%Y %H:%M:%S"   # 02.04.2025 14:30:45
         ]
-    
+
         for date_format in date_formats:
             try:
                 return datetime.strptime(date_string, date_format)
             except ValueError:
                 continue
-        
+
         raise ValueError(f"Could not parse date string: {date_string}")

--- a/test/js/component/app/__snapshots__/app.test.jsx.snap
+++ b/test/js/component/app/__snapshots__/app.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`app component > should render app element 1`] = `
       Mocked Menu
     </div>
     <div
-      class="toast-container position-absolute top-0 end-0 mt-3 me-3"
+      class="toast-container position-absolute bottom-0 end-0 mb-3 me-3"
     />
   </div>
 </DocumentFragment>

--- a/test/js/component/message/__snapshots__/message.test.jsx.snap
+++ b/test/js/component/message/__snapshots__/message.test.jsx.snap
@@ -3,56 +3,147 @@
 exports[`message component > should render error message 1`] = `
 <DocumentFragment>
   <div
-    class="toast-container position-absolute top-0 end-0 mt-3 me-3"
+    class="toast-container position-absolute bottom-0 end-0 mb-3 me-3"
   >
     <div
       aria-atomic="true"
       aria-live="assertive"
-      class="toast align-items-center bg-secondary fade show showing"
+      class="toast fade show showing"
       data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
       initialized="true"
       role="alert"
     >
       <div
-        class="d-flex"
+        class="toast-header"
       >
-        <div
-          class="ms-3 m-auto h4"
+        <i
+          class="bi bi-info-circle-fill text-primary me-2"
+        />
+        <strong
+          class="me-auto"
         >
-          <i
-            class="bi bi-exclamation-triangle-fill text-bg-secondary"
-          />
-        </div>
-        <div
-          class="toast-body text-bg-secondary"
-        >
-          foo
-        </div>
+          message.info
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
       </div>
     </div>
     <div
       aria-atomic="true"
       aria-live="assertive"
-      class="toast align-items-center bg-danger fade show showing"
+      class="toast fade show showing"
       data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
       initialized="true"
       role="alert"
     >
       <div
-        class="d-flex"
+        class="toast-header"
       >
-        <div
-          class="ms-3 m-auto h4"
+        <i
+          class="bi bi-exclamation-triangle-fill text-warning me-2"
+        />
+        <strong
+          class="me-auto"
         >
-          <i
-            class="bi bi-x-octagon-fill text-bg-danger"
-          />
-        </div>
-        <div
-          class="toast-body text-bg-danger"
+          message.warning
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
+      </div>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      class="toast fade show showing"
+      data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
+      initialized="true"
+      role="alert"
+    >
+      <div
+        class="toast-header"
+      >
+        <i
+          class="bi bi-x-octagon-fill text-danger me-2"
+        />
+        <strong
+          class="me-auto"
         >
-          foo
-        </div>
+          message.error
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`message component > should render info message 1`] = `
+<DocumentFragment>
+  <div
+    class="toast-container position-absolute bottom-0 end-0 mb-3 me-3"
+  >
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      class="toast fade show showing"
+      data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
+      initialized="true"
+      role="alert"
+    >
+      <div
+        class="toast-header"
+      >
+        <i
+          class="bi bi-info-circle-fill text-primary me-2"
+        />
+        <strong
+          class="me-auto"
+        >
+          message.info
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
       </div>
     </div>
   </div>
@@ -62,7 +153,7 @@ exports[`message component > should render error message 1`] = `
 exports[`message component > should render message container 1`] = `
 <DocumentFragment>
   <div
-    class="toast-container position-absolute top-0 end-0 mt-3 me-3"
+    class="toast-container position-absolute bottom-0 end-0 mb-3 me-3"
   />
 </DocumentFragment>
 `;
@@ -70,31 +161,72 @@ exports[`message component > should render message container 1`] = `
 exports[`message component > should render warning message 1`] = `
 <DocumentFragment>
   <div
-    class="toast-container position-absolute top-0 end-0 mt-3 me-3"
+    class="toast-container position-absolute bottom-0 end-0 mb-3 me-3"
   >
     <div
       aria-atomic="true"
       aria-live="assertive"
-      class="toast align-items-center bg-secondary fade show showing"
+      class="toast fade show showing"
       data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
       initialized="true"
       role="alert"
     >
       <div
-        class="d-flex"
+        class="toast-header"
       >
-        <div
-          class="ms-3 m-auto h4"
+        <i
+          class="bi bi-info-circle-fill text-primary me-2"
+        />
+        <strong
+          class="me-auto"
         >
-          <i
-            class="bi bi-exclamation-triangle-fill text-bg-secondary"
-          />
-        </div>
-        <div
-          class="toast-body text-bg-secondary"
+          message.info
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
+      </div>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      class="toast fade show showing"
+      data-bs-autohide="false"
+      data-oereb-message-confirm="false"
+      data-oereb-message-id="a81dad33-08cf-4b50-b0c6-d14bcc427df8"
+      initialized="true"
+      role="alert"
+    >
+      <div
+        class="toast-header"
+      >
+        <i
+          class="bi bi-exclamation-triangle-fill text-warning me-2"
+        />
+        <strong
+          class="me-auto"
         >
-          foo
-        </div>
+          message.warning
+        </strong>
+        <button
+          aria-label="Close"
+          class="btn-close"
+          type="button"
+        />
+      </div>
+      <div
+        class="toast-body"
+      >
+        foo
       </div>
     </div>
   </div>

--- a/test/js/component/message/message.test.jsx
+++ b/test/js/component/message/message.test.jsx
@@ -4,13 +4,14 @@ import {Provider} from "react-redux";
 
 import OerebMessage from "../../../../oereb_client/static/src/component/message/message";
 import MainStore from "../../../../oereb_client/static/src/store/main";
-import { error, warning } from "../../../../oereb_client/static/src/reducer/message";
+import { error, info, warning } from "../../../../oereb_client/static/src/reducer/message";
 
 describe("message component", () => {
 
   let component;
 
   beforeEach(() => {
+    vi.mock('uuid', () => ({ v4: () => 'a81dad33-08cf-4b50-b0c6-d14bcc427df8' }));
     component = render(
       <Provider store={MainStore}>
         <OerebMessage />
@@ -22,16 +23,32 @@ describe("message component", () => {
     expect(component.asFragment()).toMatchSnapshot();
   });
 
+  it("should render info message", () => {
+    act(() => {
+      MainStore.dispatch(info({
+        text: "foo",
+        confirmation: false
+      }));
+    });
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+
   it("should render warning message", () => {
     act(() => {
-      MainStore.dispatch(warning("foo"));
+      MainStore.dispatch(warning({
+        text: "foo",
+        confirmation: false
+      }));
     });
     expect(component.asFragment()).toMatchSnapshot();
   });
 
   it("should render error message", () => {
     act(() => {
-      MainStore.dispatch(error("foo"));
+      MainStore.dispatch(error({
+        text: "foo",
+        confirmation: false
+      }));
     });
     expect(component.asFragment()).toMatchSnapshot();
   });

--- a/test/js/reducer/message.test.js
+++ b/test/js/reducer/message.test.js
@@ -2,8 +2,10 @@ import {vi} from "vitest";
 
 import reducer, {
   cleanMessages,
+  close,
   error,
   showError,
+  showInfo,
   showWarning,
   warning} from "../../../oereb_client/static/src/reducer/message";
 import * as messageSlice from "../../../oereb_client/static/src/reducer/message";
@@ -22,7 +24,10 @@ describe("message reducer", () => {
 
   it("should add warning message", () => {
     let state = reducer(undefined, {});
-    state = reducer(state, warning("foo"));
+    state = reducer(state, warning({
+      text: "foo",
+      confirmation: false
+    }));
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].text).toEqual("foo");
     expect(state.messages[0].type).toEqual("warning");
@@ -32,7 +37,10 @@ describe("message reducer", () => {
 
   it("should add error message", () => {
     let state = reducer(undefined, {});
-    state = reducer(state, error("foo"));
+    state = reducer(state, error({
+      text: "foo",
+      confirmation: false
+    }));
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].text).toEqual("foo");
     expect(state.messages[0].type).toEqual("error");
@@ -40,11 +48,33 @@ describe("message reducer", () => {
     expect(typeof state.messages[0].timestamp).toBe("number");
   });
 
+  it("should remove a specific message", () => {
+    let state = reducer(undefined, {});
+    state = reducer(state, error({
+      text: "foo",
+      confirmation: false
+    }));
+    state = reducer(state, error({
+      text: "bar",
+      confirmation: false
+    }));
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[0].text).toEqual("foo");
+    expect(state.messages[1].text).toEqual("bar");
+    const messageId = state.messages[0].id;
+    state = reducer(state, close(messageId));
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].text).toEqual("bar");
+  });
+
   it("should remove timed-out messages", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2023, 1, 1, 0, 0, 0));
     let state = reducer(undefined, {});
-    state = reducer(state, warning("foo"));
+    state = reducer(state, warning({
+      text: "foo",
+      confirmation: false
+    }));
     expect(state.messages).toHaveLength(1);
     vi.setSystemTime(new Date(2023, 1, 1, 0, 0, 11));
     state = reducer(state, cleanMessages());
@@ -52,12 +82,27 @@ describe("message reducer", () => {
     vi.useRealTimers();
   });
 
+  it("should show info with async removal", () => {
+    const state = reducer(undefined, {});
+    const infoSpy = vi.spyOn(messageSlice, "info");
+    const cleanSpy = vi.spyOn(messageSlice, "cleanMessages");
+    reducer(state, showInfo("foo", false));
+    vi.waitFor(() => expect(infoSpy).toHaveBeenCalledWith({
+      text: "foo",
+      confirmation: false
+    }));
+    vi.waitFor(() => expect(cleanSpy).toHaveBeenCalled());
+  });
+
   it("should show warning with async removal", () => {
     const state = reducer(undefined, {});
     const warningSpy = vi.spyOn(messageSlice, "warning");
     const cleanSpy = vi.spyOn(messageSlice, "cleanMessages");
-    reducer(state, showWarning("foo"));
-    vi.waitFor(() => expect(warningSpy).toHaveBeenCalledWith("foo"));
+    reducer(state, showWarning("foo", false));
+    vi.waitFor(() => expect(warningSpy).toHaveBeenCalledWith({
+      text: "foo",
+      confirmation: false
+    }));
     vi.waitFor(() => expect(cleanSpy).toHaveBeenCalled());
   });
 
@@ -65,8 +110,11 @@ describe("message reducer", () => {
     const state = reducer(undefined, {});
     const errorSpy = vi.spyOn(messageSlice, "error");
     const cleanSpy = vi.spyOn(messageSlice, "cleanMessages");
-    reducer(state, showError("foo"));
-    vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith("foo"));
+    reducer(state, showError("foo", false));
+    vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith({
+      text: "foo",
+      confirmation: false
+    }));
     vi.waitFor(() => expect(cleanSpy).toHaveBeenCalled());
   });
 

--- a/test/resources/messages.yml
+++ b/test/resources/messages.yml
@@ -1,0 +1,5 @@
+messages:
+  - text:
+      en: foo
+    from: null
+    until: null


### PR DESCRIPTION
<img width="432" height="141" alt="image" src="https://github.com/user-attachments/assets/d96d4329-c7b1-4ad8-a5cc-73a82f627d9a" />

- Use configuration to specify messages
- Provide messages in multiple languages
- Messages have to be closed by the user

**Configuration**

```yaml
  # [OPTIONAL] Specify a number of notices that are shown on application start.
  # The text can be defined in multiple languages. You can also specify one or two
  # dates to automatically enable and/or disable each notice. The value "null" means
  # no restriction.
  messages:
    - text:
        en: My example notice
        de: Meine Beispielmeldung
      from: null
      until: null
```

Closes #1300 